### PR TITLE
build: use curl instead of wget for downloads

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -214,17 +214,12 @@ git_submodule_init()
 	cd -
 }
 
-GET=wget
+GET="curl -LRO"
 check()
 {
-	if ! wget --version &>/dev/null; then
-		if ! curl --version &>/dev/null; then
-			echo "Need wget or curl to download files"
-			exit 1
-		fi
-
-		# try replace wget with curl
-		GET='curl -O'
+	if ! curl --version &>/dev/null; then
+		echo "Need curl to download files"
+		exit 1
 	fi
 
 	if ! cmake --version &>/dev/null; then


### PR DESCRIPTION
I've been testing LLVM download in build phase a bit and achieved considerably better results using curl for downloading then with wget. The curl command I suggest to use is `curl -LRO $URL`.
Those flags cause curl to:
- re-downloaded partially downloaded archive replacing the partial download
- cancel download if the archive exists and is up to date

This PR should fix #64 .

Signed-off-by: Tomas Jasek <tomsik68@gmail.com>