### PR TITLE
build.sh: Set libdir for stp

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -499,6 +499,7 @@ if [ $FROM -le 3 ]; then
 	cd stp || exitmsg "Cloning failed"
 	if [ ! -d CMakeFiles ]; then
 		cmake . -DCMAKE_INSTALL_PREFIX=$PREFIX \
+			-DCMAKE_INSTALL_LIBDIR:PATH=lib \
 			-DSTP_TIMESTAMPS:BOOL="OFF" \
 			-DCMAKE_CXX_FLAGS_RELEASE=-O2 \
 			-DCMAKE_C_FLAGS_RELEASE=-O2 \


### PR DESCRIPTION
On my Fedora, STP gets installed to `install/lib64`, but the script sets `LD_LIBRARY_PATH` to `install/lib`.
This should fix it.

Alternatively, you could stop fighting individual build scripts, let them install to the arch-specific libdir and use `LD_LIBRARY_PATH='install/$LIB'` (`ld.so` would resolve `$LIB` to the arch-specific name).