### PR TITLE
Check clang version for memsafety

### DIFF
--- a/lib/symbioticpy/symbiotic/symbiotic.py
+++ b/lib/symbioticpy/symbiotic/symbiotic.py
@@ -8,7 +8,7 @@ from . options import SymbioticOptions
 from . utils import err, dbg, enable_debug, print_elapsed_time, restart_counting_time
 from . utils.process import ProcessRunner, runcmd
 from . utils.watch import ProcessWatch, DbgWatch
-from . utils.utils import print_stdout, print_stderr, get_symbiotic_dir
+from . utils.utils import print_stdout, print_stderr, get_symbiotic_dir, get_clang_version, required_version
 from . exceptions import SymbioticException
 
 class PrepareWatch(ProcessWatch):
@@ -209,6 +209,10 @@ class Symbiotic(object):
 
         if self.options.is32bit:
             cmd.append('-m32')
+
+        if self.options.property.memsafety() and required_version(get_clang_version(), "4.0.1"):
+            cmd.append('-Xclang')
+            cmd.append('-force-lifetime-markers')
 
         cmd.append('-o')
         if output is None:

--- a/lib/symbioticpy/symbiotic/utils/utils.py
+++ b/lib/symbioticpy/symbiotic/utils/utils.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from time import time
+from distutils.version import LooseVersion
 
 COLORS = {
     'DARK_BLUE': '\033[0;34m',
@@ -122,3 +123,13 @@ def get_symbiotic_dir():
     # get real path (strip off links)
     realpath = os.path.realpath(os.path.join(sys.argv[0], '..'))
     return os.path.abspath(os.path.dirname(realpath))
+
+def required_version(actual, required):
+    return LooseVersion(actual) >= LooseVersion(required)
+
+def get_clang_version():
+    (retval, lines) = process_grep(['clang', '-v'], 'version')
+    assert(retval == 0)
+    assert(len(lines) == 1)
+
+    return lines[0].split()[2].strip()


### PR DESCRIPTION
From clang's version 4.0.1 we want to use -force-lifetime-markers
option for memsafety instrumentation.