### PR TITLE
Add continuous integration support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: cpp
+sudo: true
+
+dist: xenial
+
+git:
+  depth: 1
+
+env:
+  - LLVM=4.0
+  - LLVM=5.0
+
+addons:
+  apt:
+    sources:
+      # newer gcc and clang?
+      - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+      - ubuntu-toolchain-r-test
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+    packages:
+      - libc6-dev-i386
+      - linux-libc-dev
+      - libz-dev
+      - cmake
+      - libz3-dev
+      - python3-pip
+      - python3-setuptools
+
+compiler:
+  - clang
+
+script:
+  - git clone --depth 1 https://github.com/tomsik68/travis-llvm.git
+  - cd travis-llvm
+  - chmod +x travis-llvm.sh
+  - ./travis-llvm.sh ${LLVM}
+  - cd ..
+  - sudo ln -s /usr/include/asm-generic /usr/include/asm
+  - ./system-build.sh -j8
+  - pip3 install --user benchexec
+  - PATH=$PATH:/home/travis/.local/bin
+  - cd tests/
+  - sudo chmod o+wt '/sys/fs/cgroup/cpuset/'
+  - sudo chmod o+wt '/sys/fs/cgroup/cpu,cpuacct/user.slice'
+  - sudo chmod o+wt '/sys/fs/cgroup/freezer/'
+  - sudo chmod o+wt '/sys/fs/cgroup/memory/user.slice'
+  - make
+
+notifications:
+    email: false

--- a/system-build.sh
+++ b/system-build.sh
@@ -229,6 +229,9 @@ for T in $LLVM_TOOLS; do
 	cp ${TOOL} $LLVM_PREFIX/bin
 done
 
+mkdir -p $LLVM_PREFIX/lib
+cp -Lr $(dirname $(which clang))/../lib/clang/ $LLVM_PREFIX/lib/
+
 ######################################################################
 #   dg
 ######################################################################

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export PATH=$(pwd)/../scripts:$PATH
+export PATH=$(pwd)/../install/bin/:$PATH
 benchexec symbiotic-tests.xml $@


### PR DESCRIPTION
This PR adds support for Travis CI. Symbiotic is built with LLVM versions 4.0 and 5.0. Because of build time limit, it needs to use `system-build.sh` instead of `build.sh` (because LLVM building takes too long). After building Symbiotic, regression tests are also run, but their results are not taken into account. That means, if compilation is successful but tests fail, the CI passes. We can still change this by inspecting `results.txt`.

I had to modify `system-build.sh` to copy clang's built-in headers to `$LLVM_PREFIX/lib/` (see https://clang.llvm.org/docs/LibTooling.html#builtin-includes for more information about that).

I also had to modify `run_tests.sh` to use Symbiotic in the `install` folder, because the version in scripts folder is unable to find the LLVM prefix directory when `system-build.sh` is used.

See the latest build as a proof: https://travis-ci.org/tomsik68/symbiotic/builds/539153267

Possibly fixes #73 