### PR TITLE
build: check if z3 directory exists before cloning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -643,7 +643,10 @@ if [ "$BUILD_Z3" = "yes" ]; then
 	#   Z3
 	######################################################################
 	if [ $FROM -le 4 -a "$BUILD_KLEE" = "yes" ]; then
-		git_clone_or_pull git://github.com/Z3Prover/z3 -b "z3-4.8.4" z3
+		if [ ! -d "z3" ]; then
+			git_clone_or_pull git://github.com/Z3Prover/z3 -b "z3-4.8.4" z3
+		fi
+
 		mkdir -p "z3/build" && pushd "z3/build"
 		if [ ! -d CMakeFiles ]; then
 			cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \


### PR DESCRIPTION
This allows running `build.sh` even if z3 is already built.