### PR TITLE
Allow usage of parameter '--no-link'

### DIFF
--- a/lib/symbioticpy/symbiotic/options.py
+++ b/lib/symbioticpy/symbiotic/options.py
@@ -207,7 +207,7 @@ def parse_command_line():
                                     'instrumentation-timeout=', 'version', 'help',
                                     'no-verification', 'output=', 'witness=', 'bc',
                                     'optimize=', 'malloc-never-fails',
-                                    'pta=', 'no-link', 'slicing-criterion=',
+                                    'pta=', 'no-link=', 'slicing-criterion=',
                                     'cflags=', 'cppflags=', 'link=', 'executable-witness',
                                     'verifier=','target=', 'require-slicer',
                                     'no-link-undefined', 'repeat-slicing=',


### PR DESCRIPTION
By adding a missing '=' in options parsing.

Previously, usage of `--no-link` failed.
For example:
```
# symbiotic --no-link=verifier --prp=properties/unreach-call.prp tests/realloc_true-unreach-call_true-valid-memsafety.c
ERROR: option --no-link must not have an argument
```