### PR TITLE
Minor fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ get_llvm_version()
 	fi
 }
 
-export PREFIX=`pwd`/install
+export PREFIX=${PREFIX:-`pwd`/install}
 
 # export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
 # export C_INCLUDE_PATH="$PREFIX/include:$C_INCLUDE_PATH"

--- a/build.sh
+++ b/build.sh
@@ -522,6 +522,7 @@ if [ $FROM -le 1 ]; then
 			-DLLVM_BUILD_PATH="$LLVM_BUILD_PATH" \
 			-DLLVM_DIR=$LLVM_DIR \
 			-DCMAKE_INSTALL_PREFIX=$LLVM_PREFIX \
+			-DCMAKE_INSTALL_RPATH="\$ORIGIN/../lib" \
 			${SVF_FLAGS} \
 			|| clean_and_exit 1 "git"
 	fi
@@ -548,6 +549,7 @@ if [ $FROM -le 1 ]; then
 			-DLLVM_DIR=$LLVM_DIR \
 			-DDG_PATH=$ABS_SRCDIR/dg \
 			-DCMAKE_INSTALL_PREFIX=$LLVM_PREFIX \
+			-DCMAKE_INSTALL_RPATH="\$ORIGIN/../lib" \
 			|| clean_and_exit 1 "git"
 	fi
 

--- a/scripts/precompile_bitcode_files.sh
+++ b/scripts/precompile_bitcode_files.sh
@@ -1,6 +1,5 @@
 INSTR="sbt-instrumentation/"
 LIBS="lib/"
-PREFIX="install"
 
 set -e
 

--- a/scripts/symbiotic
+++ b/scripts/symbiotic
@@ -23,7 +23,8 @@ import os
 from time import time
 
 # set path to our package
-pth = os.path.join(os.path.dirname(__file__), '../lib/symbioticpy')
+exec_path = os.readlink(__file__) if os.path.islink(__file__) else __file__
+pth = os.path.join(os.path.dirname(exec_path), '../lib/symbioticpy')
 sys.path.append(os.path.abspath(pth))
 
 from symbiotic.utils import err, dbg

--- a/system-build.sh
+++ b/system-build.sh
@@ -47,7 +47,7 @@ usage()
 	echo -e "OPTS = options for make (i. e. -j8)"
 }
 
-export PREFIX=`pwd`/install
+export PREFIX=${PREFIX:-`pwd`/install}
 export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
 export C_INCLUDE_PATH="$PREFIX/include:$C_INCLUDE_PATH"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig:$PKG_CONFIG_PATH"

--- a/system-build.sh
+++ b/system-build.sh
@@ -277,6 +277,7 @@ if [ $FROM -le 1 ]; then
 			-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
 			-DCMAKE_INSTALL_LIBDIR:PATH=lib \
 			-DCMAKE_INSTALL_PREFIX=$LLVM_PREFIX \
+			-DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
 			-DLLVM_DIR=$($LLVM_CONFIG --cmakedir) \
 			|| clean_and_exit 1 "git"
 	fi
@@ -301,6 +302,7 @@ if [ $FROM -le 1 ]; then
 			-DLLVM_DIR=$($LLVM_CONFIG --cmakedir) \
 			-DDG_PATH=$ABS_SRCDIR/dg \
 			-DCMAKE_INSTALL_PREFIX=$LLVM_PREFIX \
+			-DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
 			|| clean_and_exit 1 "git"
 	fi
 


### PR DESCRIPTION
- Allow a custom `$PREFIX` path.
- Set rpath for `dg` and `sbt-slicer` so that they can be run independently from Symbiotic.
- Use symbolic links for system LLVM tools.
- Check whether Symbiotic is executed from a symbolic link.

EDIT: Some changes moved to #151.