### PR TITLE
verifier.py: convert output lines to strings

### DIFF
--- a/lib/symbioticpy/symbiotic/verifier.py
+++ b/lib/symbioticpy/symbiotic/verifier.py
@@ -73,7 +73,7 @@ class SymbioticVerifier(object):
 
         print_elapsed_time('INFO: Verification time', color='WHITE')
         res = self._tool.determine_result(returncode, 0,
-                                          watch.getLines(), False)
+                                          map(lambda x: x.decode('utf-8'), watch.getLines()), False)
         if res.lower().startswith('error'):
             for line in watch.getLines():
                 print_stderr(line.decode('utf-8'),


### PR DESCRIPTION
benchexec modules expect output lines to be a list of strings, while
watch returns list of bytes objects.
this change allows benchexec modules to be used with Symbiotic without
modifications.

Here is a traceback of an error this PR addresses:
```
|> /var/tmp/xjasek/predatorhp-llvm/predatorHP.py --propertyfile /var/tmp/xjasek/build_archive/symbiotic-predatorhp/install/properties/valid-memsafety.prp /tmp/symbiotic-c6fbzr87/code-pr-inst-pr-opt-pr-opt-pr.bc --compiler-options=-m32
UNKNOWN
INFO: Verification time: 0.2759096622467041
Traceback (most recent call last):
  File "./symbiotic", line 129, in <module>
    res = symbiotic.run()
  File "/var/tmp/xjasek/build_archive/symbiotic-predatorhp/install/lib/symbioticpy/symbiotic/symbiotic.py", line 151, in run
    return self._run_symbiotic()
  File "/var/tmp/xjasek/build_archive/symbiotic-predatorhp/install/lib/symbioticpy/symbiotic/symbiotic.py", line 89, in _run_symbiotic
    res = verifier.run()
  File "/var/tmp/xjasek/build_archive/symbiotic-predatorhp/install/lib/symbioticpy/symbiotic/verifier.py", line 93, in run
    return self.run_verification()
  File "/var/tmp/xjasek/build_archive/symbiotic-predatorhp/install/lib/symbioticpy/symbiotic/verifier.py", line 89, in run_verification
    return self._run_verifier(cmd)
  File "/var/tmp/xjasek/build_archive/symbiotic-predatorhp/install/lib/symbioticpy/symbiotic/verifier.py", line 76, in _run_verifier
    watch.getLines(), False)
  File "/usr/local/lib/python3.6/dist-packages/benchexec/tools/predatorhp.py", line 56, in determine_result
    output = '\n'.join(output)
TypeError: sequence item 0: expected str instance, bytes found
```