### PR TITLE
utils/process.py: Fix possible discarding of subprocess output

### DIFF
--- a/lib/symbioticpy/symbiotic/utils/process.py
+++ b/lib/symbioticpy/symbiotic/utils/process.py
@@ -43,9 +43,8 @@ class ProcessRunner(object):
             msg = ' '.join(cmd) + '\n'
             raise SymbioticException(msg + str(e))
 
-        while True:
-            line = ProcessRunner.current_process.stdout.readline()
-            if line == b'' and ProcessRunner.current_process.poll() is not None:
+        for line in ProcessRunner.current_process.stdout:
+            if line == b'':
                 break
 
             watch.putLine(line)


### PR DESCRIPTION
ProcessRunner may discard some parts of a sub-process output whenever
the sub-process writes of the pipe and subsequently exits in the exact
moment between the lines below.

```python
line = ProcessRunner.current_process.stdout.readline()
if line == b'' and ProcessRunner.current_process.poll() is not None:
```

This behaviour could be observed when multiple instances of Symbiotic
were launched in parallel.

Fixes #138.