### PR TITLE
targets/klee.py: Fix --full-instrumentation option

### DIFF
--- a/lib/symbioticpy/symbiotic/targets/klee.py
+++ b/lib/symbioticpy/symbiotic/targets/klee.py
@@ -158,7 +158,7 @@ class KleeToolFullInstrumentation(KleeBase):
 
         found = []
         for line in output:
-            fnd = self._parse_klee_output_line(line.decode('ascii'))
+            fnd = self._parse_klee_output_line(line)
             if fnd:
                 found.append(fnd)
 


### PR DESCRIPTION
Fixes:
```
$ symbiotic --full-instrumentation empty_main.c
...
  File "/opt/symbiotic/lib/symbioticpy/symbiotic/verifier.py", line 75, in _run_verifier
    res = self._tool.determine_result(returncode, 0,
  File "/opt/symbiotic/lib/symbioticpy/symbiotic/targets/klee.py", line 390, in determine_result
    return self.FullInstr.determine_result(returncode, returnsignal, output, isTimeout)
  File "/opt/symbiotic/lib/symbioticpy/symbiotic/targets/klee.py", line 161, in determine_result
    fnd = self._parse_klee_output_line(line.decode('ascii'))
AttributeError: 'str' object has no attribute 'decode'
```