### PR TITLE
Fix transforms warnings

### DIFF
--- a/transforms/InstrumentNontermination.cpp
+++ b/transforms/InstrumentNontermination.cpp
@@ -407,6 +407,7 @@ bool InstrumentNontermination::instrumentEmptyLoop(Loop *L) {
   }
 
   llvm::errs() << "Instrumented an empty loop with abort.\n";
+  return true;
 }
 
 static RegisterPass<InstrumentNontermination> CL("instrument-nontermination",

--- a/transforms/MakeNondet.cpp
+++ b/transforms/MakeNondet.cpp
@@ -240,7 +240,7 @@ static std::string strip(const std::string& str) {
     size_t start = 0, end = str.length() - 1;
     while (start < str.length() && std::isspace(str[start]))
         ++start;
-    while (end >= 0 && std::isspace(str[end]))
+    while (std::isspace(str[end]))
         --end;
     assert(start <= end);
     return str.substr(start, end - start + 1);
@@ -250,10 +250,10 @@ static std::string lastWord(const std::string& str) {
     size_t end = str.length() - 1;
 
     // skip the whitespace at the end
-    while (end >= 0 && std::isspace(str[end]))
+    while (std::isspace(str[end]))
         --end;
 
-    while (end >= 0 && !std::isspace(str[end])) {
+    while (!std::isspace(str[end])) {
         if (end == 0)
             return str;
 

--- a/transforms/PrepareOverflows.cpp
+++ b/transforms/PrepareOverflows.cpp
@@ -64,12 +64,15 @@ struct PrepareOverflows : public FunctionPass {
       switch (II->getIntrinsicID()) {
           case Intrinsic::sadd_with_overflow:
             handleSBinOpIntrinsic(II, Instruction::BinaryOps::Add);
+            break;
           case Intrinsic::ssub_with_overflow:
             handleSBinOpIntrinsic(II, Instruction::BinaryOps::Sub);
+            break;
           case Intrinsic::smul_with_overflow:
             handleSBinOpIntrinsic(II, Instruction::BinaryOps::Mul);
+            break;
           default:
-            return;
+            break;
       }
   }
 

--- a/transforms/RemoveInfiniteLoops.cpp
+++ b/transforms/RemoveInfiniteLoops.cpp
@@ -69,7 +69,7 @@ static RegisterPass<RemoveInfiniteLoops> RIL("remove-infinite-loops",
                                              "and replace them with exit(0)");
 char RemoveInfiniteLoops::ID;
 
-void CloneMetadata(const llvm::Instruction *i1, llvm::Instruction *i2);
+bool CloneMetadata(const llvm::Instruction *i1, llvm::Instruction *i2);
 
 bool RemoveInfiniteLoops::runOnFunction(Function &F) {
   Module *M = F.getParent();

--- a/transforms/Unrolling.cpp
+++ b/transforms/Unrolling.cpp
@@ -100,7 +100,7 @@ static void redirectEdges(const BasicBlock *origB,
 
 static void replaceSuccessor(const std::vector<BasicBlock *>& Blocks,
                              BasicBlock *oldB, BasicBlock *newB) {
-  for (auto i = 0; i < Blocks.size(); ++i) {
+  for (size_t i = 0; i < Blocks.size(); ++i) {
     auto origTI = Blocks[i]->getTerminator();
     for (unsigned i = 0; i < origTI->getNumSuccessors(); ++i) {
       auto succ = origTI->getSuccessor(i);
@@ -124,7 +124,7 @@ static void redirectValues(BasicBlock *newB,
      //for (auto i = 0; i < PHI->getNumIncomingValues(); ++i) {
      //}
     } else {
-      for (auto i = 0; i < I.getNumOperands(); ++i) {
+      for (unsigned i = 0; i < I.getNumOperands(); ++i) {
         if (VMap.count(I.getOperand(i))) {
           I.setOperand(i, VMap[I.getOperand(i)]);
         }
@@ -151,7 +151,7 @@ cloneLoopBody(Function *F, const std::vector<BasicBlock *> Blocks) {
 
   // we got new basic blocks, now redirect the edges
   // and PHI values and such
-  for (auto i = 0; i < Blocks.size(); ++i) {
+  for (size_t i = 0; i < Blocks.size(); ++i) {
       redirectEdges(Blocks[i], NewBlocks[i], BlocksMap);
       redirectValues(NewBlocks[i], VMap, BlocksMap);
   }


### PR DESCRIPTION
This PR fixes warnings, that were uncovered by #152 as the previous usage of LLVM CMake machinery suppressed them.

The only warning that still persists is the following one. If you tell me the expected return value, I can can fix it additionally.
``` 
InstrumentNontermination.cpp: In member function ‘bool InstrumentNontermination::instrumentEmptyLoop(llvm::Loop*)’:
InstrumentNontermination.cpp:394:1: warning: no return statement in function returning non-void [-Wreturn-type]
  394 | }
      | ^
```