### PR TITLE
tool.py: set slicing crit for overflow prp

### DIFF
--- a/lib/symbioticpy/symbiotic/targets/tool.py
+++ b/lib/symbioticpy/symbiotic/targets/tool.py
@@ -161,5 +161,10 @@ class SymbioticBaseTool(object):
         if prop.unreachcall():
             return (prop.getcalls(), [])
 
+        if prop.signedoverflow():
+            # default config file is 'config.json'
+            # slice wrt asserts checking for the overflow
+            return (['__assert_fail'],[])
+
         return ([],[])
 

--- a/lib/symbioticpy/symbiotic/transform.py
+++ b/lib/symbioticpy/symbiotic/transform.py
@@ -474,6 +474,8 @@ class SymbioticCC(object):
         else:
             crit, opts = ['__assert_fail,__VERIFIER_error'], []
 
+        assert len(crit) > 0
+
         output = '{0}.sliced'.format(self.curfile[:self.curfile.rfind('.')])
 
 


### PR DESCRIPTION
When Symbiotic checks for `--prp no-overflow`, no slicing criterion is supplied which results in an empty program. The slicer is started as `|> timeout 300 sbt-slicer -c  -pta fi /tmp/symbiotic-nhs2l7nz/code-pr-pr-inst-opt.bc` .
This commit adds `-c __assert_fail` as the instrumentation functions use `assert(/* no overflow occured */);`.