### PR TITLE
tool.py: update slicing crit for overflows

### DIFF
--- a/lib/symbioticpy/symbiotic/targets/tool.py
+++ b/lib/symbioticpy/symbiotic/targets/tool.py
@@ -164,7 +164,7 @@ class SymbioticBaseTool(object):
         if prop.signedoverflow():
             # default config file is 'config.json'
             # slice wrt asserts checking for the overflow
-            return (['__assert_fail'],[])
+            return (['__assert_fail', '__VERIFIER_error'],[])
 
         return ([],[])
 


### PR DESCRIPTION
ubsan overflow checks are replaced by calls of `__VERIFIER_error` and this prevents them from being sliced away. Alternatively, we could replace them by something else in the transform pass.