### PR TITLE
transforms-llvm11: Fix calls to instruction constructors

### DIFF
--- a/transforms/DeleteUndefined.cpp
+++ b/transforms/DeleteUndefined.cpp
@@ -310,9 +310,7 @@ void DeleteUndefined::defineFunction(Module *M, Function *F)
 #endif
         nullptr,
         "",
-        static_cast<Instruction*>(nullptr)); // to prevent constructor ambiguity
-
-    block->getInstList().push_back(AI);
+        block);
 
     // insert initialization of the new global variable
     // at the beginning of main

--- a/transforms/InitializeUninitialized.cpp
+++ b/transforms/InitializeUninitialized.cpp
@@ -256,6 +256,9 @@ bool InitializeUninitialized::runOnFunction(Function &F)
                 AI->getType()->getAddressSpace(),
 #endif
                 nullptr,
+#if LLVM_VERSION_MAJOR >= 11
+                AI->getAlign(),
+#endif
                 "",
                 static_cast<Instruction*>(nullptr));
             AIS->insertAfter(AI);
@@ -276,8 +279,19 @@ bool InitializeUninitialized::runOnFunction(Function &F)
                 AIS->getType()->getPointerElementType(),
                 AIS,
                 "",
+#if LLVM_VERSION_MAJOR >= 11
+                false,
+                AIS->getAlign(),
+#endif
                 static_cast<Instruction*>(nullptr));
-            SI = new StoreInst(LI, AI, false, static_cast<Instruction*>(nullptr));
+            SI = new StoreInst(
+                LI,
+                AI,
+                false,
+#if LLVM_VERSION_MAJOR >= 11
+                LI->getAlign(),
+#endif
+                static_cast<Instruction*>(nullptr));
             LI->insertAfter(CI);
             SI->insertAfter(LI);
 

--- a/transforms/MakeNondet.cpp
+++ b/transforms/MakeNondet.cpp
@@ -156,6 +156,9 @@ void MakeNondet::replaceCall(Module& M, CallInst *CI,
       0,
 #endif
       nullptr,
+#if LLVM_VERSION_MAJOR >= 11
+      M.getDataLayout().getPrefTypeAlign(CI->getType()),
+#endif
       "",
       static_cast<Instruction*>(nullptr));
 
@@ -183,6 +186,10 @@ void MakeNondet::replaceCall(Module& M, CallInst *CI,
 #endif
       AI,
       name,
+#if LLVM_VERSION_MAJOR >= 11
+      false,
+      AI->getAlign(),
+#endif
       static_cast<Instruction*>(nullptr));
 
   new_CI->insertBefore(CI);


### PR DESCRIPTION
Unfortunately, the previous patch regarding the instruction constructors (2442de5bd0c5d52714f13814d6a2ac031130c897), that I made, crashes with LLVM 11 (older releases are fine). It turned out that the instruction alignment now must be either deduced from the target `BasicBlock` or supplied explicitly.

Sorry for the hassle. I have tested this patch with LLVM 9-11.