### PR TITLE
transforms: Support LLVM 12

### DIFF
--- a/transforms/CloneMetadata.cpp
+++ b/transforms/CloneMetadata.cpp
@@ -53,7 +53,7 @@ bool CloneMetadata(const llvm::Instruction *i1, llvm::Instruction *i2)
     } else {
       DebugLoc DL;
       if (auto SP = i1->getParent()->getParent()->getSubprogram()) {
-        DL = DebugLoc::get(SP->getScopeLine(), 0, SP);
+        DL = DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP);
       }
       i2->setDebugLoc(DL);
     }


### PR DESCRIPTION
* Supported: LLVM 12 final
* Changes so far:
    *  transforms: Replace `DebugLoc::get` with `DILocation::get` in `CloneMetadata`
    *  transforms.py: Implement optimization name selection based on used LLVM version