### PR TITLE
symbiotic: Print sys.argv contents to the standard output in debug mode

### DIFF
--- a/scripts/symbiotic
+++ b/scripts/symbiotic
@@ -87,6 +87,7 @@ if __name__ == "__main__":
     start_time = time()
 
     opts, sources = parse_command_line()
+    dbg("Argv: {0}".format(" ".join(sys.argv)))
 
     if opts.dump_env_only:
         setup = SetupSymbiotic(opts)


### PR DESCRIPTION
This is very useful for automated processing of the results so that users
know how to reproduce it afterwards from the report itself.