### PR TITLE
system-build.sh: recopy the amalgamated jsoncpp sources if needed

### DIFF
--- a/system-build.sh
+++ b/system-build.sh
@@ -441,7 +441,7 @@ if [ $FROM -le 6 ]; then
 	pushd "$SRCDIR/sbt-instrumentation" || exitmsg "Cloning failed"
 
 	# bootstrap JSON library if needed
-	if [ ! -f jsoncpp/dist/jsoncpp.cpp ]; then
+	if [ ! -f src/jsoncpp.cpp ]; then
 		./bootstrap-json.sh || exitmsg "Failed generating json files"
 	fi
 


### PR DESCRIPTION
Fixes the following issue:
```console
$ git clean -dfx
$ git clean submodule foreach git clean -dfx
$ ./system-build
...
CMake Error at src/CMakeLists.txt:23 (add_executable):
  Cannot find source file:

    jsoncpp.cpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc

CMake Error at src/CMakeLists.txt:23 (add_executable):
  No SOURCES given to target: sbt-instr

CMake Generate step failed.  Build files cannot be regenerated correctly.
```