### PR TITLE
tests/run_tests.sh: Remove hack to get path to LLVM binariers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,12 +163,17 @@ jobs:
             # See https://systemd.io/TESTING_WITH_SANITIZERS for details.
             export LD_PRELOAD="$(clang-${{matrix.llvm}} -print-file-name=libclang_rt.asan-x86_64.so)"
             export LD_LIBRARY_PATH="$(dirname $LD_PRELOAD)"
-
-            # ASAN and UBSAN expect unversioned llvm-symbolizer in PATH.
-            export PATH="$(llvm-config-${{matrix.llvm}} --bindir):$PATH"
           else
             export LD_PRELOAD="$(gcc -print-file-name=libasan.so)"
           fi
+
+          # Make symbiotic use correct clang & friends from PATH (e.g. no
+          # disguised ccache or problems with unversioned tools not being
+          # in PATH).
+          #
+          # Also, clang's ASAN and UBSAN expect unversioned llvm-symbolizer
+          # in PATH.
+          export PATH="$(llvm-config-${{matrix.llvm}} --bindir):$PATH"
 
           # Due to LD_PRELOAD above, leak sanitizer was reporting leaks
           # literally in everything that was executed, e.g. make, shell,

--- a/lib/symbioticpy/symbiotic/environment.py
+++ b/lib/symbioticpy/symbiotic/environment.py
@@ -10,18 +10,15 @@ def _vers_are_same(v1, v2):
     parts2 = v2.split('.')
 
     # compare major and minor versions, ignore micro version
-    for i in range(0,2):
-        if parts1[i] != parts2[i]:
-            return False
-    return True
+    return all(parts1[i] == parts2[i] for i in range(2))
 
 def _check_clang_in_path(llvm_version):
     versline = process_grep(['clang', '-v'], 'clang version')
-    if versline[0] == 0 and len(versline[1]) == 1:
-        parts = versline[1][0].split()
-        return _vers_are_same(parts[2].decode('utf-8'), llvm_version)
+    if versline[0] != 0 or len(versline[1]) != 1:
+        return False
 
-    return False
+    parts = versline[1][0].split()
+    return _vers_are_same(parts[2].decode('utf-8'), llvm_version)
 
 def _set_symbiotic_environ(tool, env, opts):
     env.cwd = getcwd()
@@ -33,10 +30,7 @@ def _set_symbiotic_environ(tool, env, opts):
             env.prepend('C_INCLUDE_DIR', p)
 
     # check whether we are in distribution directory or in the developement directory
-    if isfile('{0}/build.sh'.format(env.symbiotic_dir)):
-        opts.devel_mode = True
-    else:
-        opts.devel_mode = False
+    opts.devel_mode = isfile('{0}/build.sh'.format(env.symbiotic_dir))
 
     llvm_version = tool.llvm_version()
     llvm_prefix = '{0}/llvm-{1}'.format(env.symbiotic_dir, llvm_version)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
+set -ex
+
 # run symbiotic from the scripts/ preferably, so that the tests use
 # the current (development) version
 PATH="$PWD/../scripts:$PWD/../install/bin/:$PATH"
 
-# use llvm tools linked to symbiotic's install directory
-# FIXME: this is a really ugly hack
-LLVM_VERSION="$(symbiotic --version | grep 'LLVM' | cut -d' ' -f3)"
-export PATH="$PWD/../install/llvm-$LLVM_VERSION/bin:$PATH"
+# use LLVM tools linked to symbiotic's install directory
+ENV_CMD="$(symbiotic --debug=all --dump-env-cmd)"
+eval "$ENV_CMD"
 
 # sanitizer settings
 export ASAN_OPTIONS=detect_leaks=0


### PR DESCRIPTION
Use symbiotic's `--dump-env-cmd` to populate the `PATH` environment variable.  Note that using the following construct is intentional so that `set -e` is honoured:
```bash
ENV_CMD="$(symbiotic --dump-env-cmd)"
eval "$ENV_CMD"
```
as can be seen here:
```console
$ bash -xc 'set -e; eval "$(false)"; echo what?'
+ set -e
++ false
+ eval ''
+ echo 'what?'
what?
$ echo $?
0
$ bash -xc 'set -e; ENV_CMD="$(false)"; eval "$ENV_CMD"; echo what?'
+ set -e
++ false
+ ENV_CMD=
$ echo $?
1
```

EDIT: typo