### PR TITLE
gitmodules: Update `sbt-slicer` URL to use `https`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	ignore = untracked
 [submodule "sbt-slicer"]
 	path = sbt-slicer
-	url = git://github.com/staticafi/sbt-slicer
+	url = https://github.com/staticafi/sbt-slicer
 	ignore = untracked
 [submodule "sbt-instrumentation"]
 	path = sbt-instrumentation


### PR DESCRIPTION
Support for `git://` was removed by GitHub.

Related: https://github.blog/2021-09-01-improving-git-protocol-security-github/
Fixes:
```
Cloning into '/home/lukas/rpm-symbiotic/srpm/symbiotic/sbt-slicer'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/staticafi/sbt-slicer' into submodule path '/home/lukas/rpm-symbiotic/srpm/symbiotic/sbt-slicer' failed
Failed to clone 'sbt-slicer'. Retry scheduled
```