### PR TITLE
Make submodules track master branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,19 +2,24 @@
 	path = dg
 	url = https://github.com/mchalupa/dg
 	ignore = untracked
+	branch = master
 [submodule "sbt-slicer"]
 	path = sbt-slicer
 	url = https://github.com/staticafi/sbt-slicer
 	ignore = untracked
+	branch = master
 [submodule "sbt-instrumentation"]
 	path = sbt-instrumentation
 	url = https://github.com/staticafi/sbt-instrumentation
 	ignore = untracked
+	branch = master
 [submodule "klee"]
 	path = klee
 	url = https://github.com/staticafi/klee
 	ignore = untracked
+	branch = 9.0.0-dev
 [submodule "llvm2c"]
 	path = llvm2c
 	url = https://github.com/staticafi/llvm2c
 	ignore = untracked
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,8 @@
 [submodule "klee"]
 	path = klee
 	url = https://github.com/staticafi/klee
+	ignore = untracked
 [submodule "llvm2c"]
 	path = llvm2c
 	url = https://github.com/staticafi/llvm2c
+	ignore = untracked


### PR DESCRIPTION
As agreed on Monday's (9. 5.) meeting, from now on the submodules should track changes in corresponding `master` branches only. Only these branches are now considered to be stable.

If you want to update the modules to the HEAD, just run `git submodule update --remote` and commit the changes to this repo.