### PR TITLE
Dependabot: add dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    # Files stored in repository root
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "trtikm"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "lzaoral"


### PR DESCRIPTION
This should enable Dependabot so that it will automatically create PRs with CI or git submodule related updates, run the build and test-suite.  So that we only have to merge these changes (if the CI will be green).

Depends on #227