### PR TITLE
CI: rename `master` to `main`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,10 +3,10 @@ name: Linux CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build64:


### PR DESCRIPTION
The default branch is now called `main`.