### PR TITLE
build.sh: replace git protocol with https when cloning repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run `build.sh` or `system-build.sh` script to compile Symbiotic:
 $ cd symbiotic
 $ ./build.sh -j2
 ```
-The difference betwee `build.sh` and `system-build.sh` is that
+The difference between `build.sh` and `system-build.sh` is that
 `system-build.sh` will try to build only the components of Symbiotic, using the
 system's packages.  `build.sh`, on the other hand, tries to build also the most
 of the missing dependencies, including LLVM, z3, etc.

--- a/build.sh
+++ b/build.sh
@@ -636,7 +636,7 @@ if [ "$BUILD_STP" = "yes" ]; then
 	#   minisat
 	######################################################################
 	if [ $FROM -le 4  -a "$BUILD_KLEE" = "yes" ]; then
-		git_clone_or_pull git://github.com/stp/minisat.git minisat
+		git_clone_or_pull https://github.com/stp/minisat.git minisat
 		pushd minisat
 		mkdir -p build
 		cd build || exitmsg "error"
@@ -662,7 +662,7 @@ if [ "$BUILD_STP" = "yes" ]; then
 	#   STP
 	######################################################################
 	if [ $FROM -le 4  -a "$BUILD_KLEE" = "yes" ]; then
-		git_clone_or_pull git://github.com/stp/stp.git stp
+		git_clone_or_pull https://github.com/stp/stp.git stp
 		cd stp || exitmsg "Cloning failed"
 		if [ ! -d CMakeFiles ]; then
 			cmake . -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -723,7 +723,7 @@ if [ "$BUILD_Z3" = "yes" ]; then
 	######################################################################
 	if [ $FROM -le 4 -a "$BUILD_KLEE" = "yes" ]; then
 		if [ ! -d "z3" ]; then
-			git_clone_or_pull git://github.com/Z3Prover/z3 -b "z3-4.8.4" z3
+			git_clone_or_pull https://github.com/Z3Prover/z3 -b "z3-4.8.4" z3
 		fi
 
 		mkdir -p "z3/build" && pushd "z3/build"

--- a/docs/building.md
+++ b/docs/building.md
@@ -111,7 +111,7 @@ later stages. If you change the paths, you must fix them later when compiling
 KLEE inside `system-build.sh` script:
 
 ```
-git clone git://github.com/Z3Prover/z3 -b "z3-4.8.4" z3
+git clone https://github.com/Z3Prover/z3 -b "z3-4.8.4" z3
 mkdir -p "z3/build" && pushd "z3/build"
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j4


### PR DESCRIPTION
When trying to build symbiotic using the `build.sh` script on a system without  `z3` installed, the build fails on timeout while trying to clone `Z3Prover/z3` repository. According to [this GitHub post](https://github.blog/2021-09-01-improving-git-protocol-security-github/), the support for `git://` protocol has been dropped, explaining the timeouts when cloning `z3` since the current repository URL uses the `git://` protocol.

This patch replaces all GitHub URLs that relied on the `git://` protocol, with ones that use `https:/`. This patch fixes a small typo in README.md. If it is undesired to have this change within one commit, there is no problem in splitting it into multiple commits.