### PR TITLE
remove unsupported --libc=klee option from help message

### DIFF
--- a/lib/symbioticpy/symbiotic/options.py
+++ b/lib/symbioticpy/symbiotic/options.py
@@ -457,7 +457,6 @@ where OPTS can be following:
                                  by providing a string when-opt-what, e.g. before-opt-iconstprop
     --no-optimize                Don't optimize the code (same as --optimize=none)
     --no-instrument              Don't instrument the code, for debugging.
-    --libc=klee                  Link klee-libc.bc to the module
     --repeat-slicing=N           Repeat slicing N times
     --prp=property               Specify property that should hold. It is either LTL formula
                                  as specivied by SV-COMP, or one of following shortcuts:


### PR DESCRIPTION
The help message mentions the possibility to use `--libc=klee` option, however, no such option is passed to `getopt`, nor is it handled while iterating over supplied options. Using this option causes symbiotic to exit with `ERROR: option --libc not recognized`.